### PR TITLE
Revert "Minimal versions workaround for tiny_http"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ dependencies = [
  "git_info",
  "lignin 0.1.0 (git+https://github.com/Tamschi/lignin.git?branch=develop)",
  "lignin-html",
- "log",
  "num_cpus",
  "rhizome",
  "tiny_http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ maintenance = { status = "experimental" } # This may differ between branches.
 [dependencies]
 asteracea = { git = "https://github.com/Tamschi/Asteracea.git", branch = "develop" }
 lignin-html = { git = "https://github.com/Tamschi/lignin-html.git", branch = "develop" }
-log = "0.4.4" # Minimal versions workaround for tiny_http.
 num_cpus = "1.13.1"
 rhizome = { git = "https://github.com/Tamschi/rhizome.git", branch = "develop" }
 tiny_http = "0.11.0"


### PR DESCRIPTION
This reverts the `-Z minimal-versions` workaround for the tiny_http/log dependency.

See https://github.com/tiny-http/tiny-http/issues/223.